### PR TITLE
Create explicit `hyperdrive-net` network and provide configurable mapping to network name and external 

### DIFF
--- a/install/deploy/templates/bn.tmpl
+++ b/install/deploy/templates/bn.tmpl
@@ -27,7 +27,10 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - /var/lib/hyperdrive/data/{{.Hyperdrive.ProjectName}}:/secrets:ro
     networks:
-      - hyperdrive-net
+      - net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.LocalBeaconClient.BeaconNode}}
@@ -66,5 +69,11 @@ services:
       - dac_override
     security_opt:
       - no-new-privileges
+networks:
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}
 volumes:
   {{.Hyperdrive.BeaconNodeDataVolume}}:

--- a/install/deploy/templates/bn.tmpl
+++ b/install/deploy/templates/bn.tmpl
@@ -27,7 +27,7 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - /var/lib/hyperdrive/data/{{.Hyperdrive.ProjectName}}:/secrets:ro
     networks:
-      - net
+      - hyperdrive-network
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.LocalBeaconClient.BeaconNode}}
@@ -67,6 +67,8 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  net:
+  hyperdrive-network:
+    name: {{.Hyperdrive.DockerNetwork}}
+    external: true
 volumes:
   {{.Hyperdrive.BeaconNodeDataVolume}}:

--- a/install/deploy/templates/bn.tmpl
+++ b/install/deploy/templates/bn.tmpl
@@ -27,7 +27,7 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - /var/lib/hyperdrive/data/{{.Hyperdrive.ProjectName}}:/secrets:ro
     networks:
-      - hyperdrive-network
+      - hyperdrive-net
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.LocalBeaconClient.BeaconNode}}
@@ -66,9 +66,5 @@ services:
       - dac_override
     security_opt:
       - no-new-privileges
-networks:
-  hyperdrive-network:
-    name: {{.Hyperdrive.DockerNetwork}}
-    external: true
 volumes:
   {{.Hyperdrive.BeaconNodeDataVolume}}:

--- a/install/deploy/templates/daemon.tmpl
+++ b/install/deploy/templates/daemon.tmpl
@@ -25,7 +25,10 @@ services:
       - "{{$module}}"
       {{- end}}
     networks:
-      - hyperdrive-net
+      - net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
     cap_drop:
       - all
     cap_add:
@@ -34,6 +37,8 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  hyperdrive-net:
-    name: {{.Hyperdrive.DockerNetwork}}
-    external: {{.Hyperdrive.DockerNetworkIsExternal}}
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}

--- a/install/deploy/templates/daemon.tmpl
+++ b/install/deploy/templates/daemon.tmpl
@@ -36,4 +36,4 @@ services:
 networks:
   hyperdrive-net:
     name: {{.Hyperdrive.DockerNetwork}}
-    external: true
+    external: {{.Hyperdrive.DockerNetworkIsExternal}}

--- a/install/deploy/templates/daemon.tmpl
+++ b/install/deploy/templates/daemon.tmpl
@@ -25,7 +25,7 @@ services:
       - "{{$module}}"
       {{- end}}
     networks:
-      - net
+      - hyperdrive-network
     cap_drop:
       - all
     cap_add:
@@ -34,4 +34,6 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  net:
+  hyperdrive-network:
+    name: {{.Hyperdrive.DockerNetwork}}
+    external: true

--- a/install/deploy/templates/daemon.tmpl
+++ b/install/deploy/templates/daemon.tmpl
@@ -25,7 +25,7 @@ services:
       - "{{$module}}"
       {{- end}}
     networks:
-      - hyperdrive-network
+      - hyperdrive-net
     cap_drop:
       - all
     cap_add:
@@ -34,6 +34,6 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  hyperdrive-network:
+  hyperdrive-net:
     name: {{.Hyperdrive.DockerNetwork}}
     external: true

--- a/install/deploy/templates/ec.tmpl
+++ b/install/deploy/templates/ec.tmpl
@@ -19,7 +19,10 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - /var/lib/hyperdrive/data/{{.Hyperdrive.ProjectName}}:/secrets
     networks:
-      - hyperdrive-net
+      - net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.LocalExecutionClient.ExecutionClient}}
@@ -55,5 +58,11 @@ services:
       - dac_override
     security_opt:
       - no-new-privileges
+networks:
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}
 volumes:
   {{.Hyperdrive.ExecutionClientDataVolume}}:

--- a/install/deploy/templates/ec.tmpl
+++ b/install/deploy/templates/ec.tmpl
@@ -19,7 +19,7 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - /var/lib/hyperdrive/data/{{.Hyperdrive.ProjectName}}:/secrets
     networks:
-      - hyperdrive-network
+      - hyperdrive-net
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.LocalExecutionClient.ExecutionClient}}
@@ -55,9 +55,5 @@ services:
       - dac_override
     security_opt:
       - no-new-privileges
-networks:
-  hyperdrive-network:
-    name: {{.Hyperdrive.DockerNetwork}}
-    external: true
 volumes:
   {{.Hyperdrive.ExecutionClientDataVolume}}:

--- a/install/deploy/templates/ec.tmpl
+++ b/install/deploy/templates/ec.tmpl
@@ -19,7 +19,7 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - /var/lib/hyperdrive/data/{{.Hyperdrive.ProjectName}}:/secrets
     networks:
-      - net
+      - hyperdrive-network
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.LocalExecutionClient.ExecutionClient}}
@@ -56,6 +56,8 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  net:
+  hyperdrive-network:
+    name: {{.Hyperdrive.DockerNetwork}}
+    external: true
 volumes:
   {{.Hyperdrive.ExecutionClientDataVolume}}:

--- a/install/deploy/templates/grafana.tmpl
+++ b/install/deploy/templates/grafana.tmpl
@@ -19,8 +19,6 @@ services:
       - "{{.Hyperdrive.GetUserDirectory}}/grafana-prometheus-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml"
       - "grafana-storage:/var/lib/grafana"
     networks:
-      - net
-networks:
-  net:
+      - hyperdrive-net
 volumes:
   grafana-storage:

--- a/install/deploy/templates/grafana.tmpl
+++ b/install/deploy/templates/grafana.tmpl
@@ -19,6 +19,15 @@ services:
       - "{{.Hyperdrive.GetUserDirectory}}/grafana-prometheus-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml"
       - "grafana-storage:/var/lib/grafana"
     networks:
-      - hyperdrive-net
+      - net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
+networks:
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}
 volumes:
   grafana-storage:

--- a/install/deploy/templates/modules/stakewise/sw_daemon.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_daemon.tmpl
@@ -20,7 +20,10 @@ services:
       - "--module-dir"
       - "{{$module_dir}}"
     networks:
-      - hyperdrive-net
+      - net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
     cap_drop:
       - all
     cap_add:
@@ -28,3 +31,9 @@ services:
       - chown
     security_opt:
       - no-new-privileges
+networks:
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}

--- a/install/deploy/templates/modules/stakewise/sw_daemon.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_daemon.tmpl
@@ -20,7 +20,7 @@ services:
       - "--module-dir"
       - "{{$module_dir}}"
     networks:
-      - net
+      - hyperdrive-network
     cap_drop:
       - all
     cap_add:
@@ -29,4 +29,6 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  net:
+  hyperdrive-network:
+    name: {{.Hyperdrive.DockerNetwork}}
+    external: true

--- a/install/deploy/templates/modules/stakewise/sw_daemon.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_daemon.tmpl
@@ -20,7 +20,7 @@ services:
       - "--module-dir"
       - "{{$module_dir}}"
     networks:
-      - hyperdrive-network
+      - hyperdrive-net
     cap_drop:
       - all
     cap_add:
@@ -28,7 +28,3 @@ services:
       - chown
     security_opt:
       - no-new-privileges
-networks:
-  hyperdrive-network:
-    name: {{.Hyperdrive.DockerNetwork}}
-    external: true

--- a/install/deploy/templates/modules/stakewise/sw_operator.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_operator.tmpl
@@ -33,14 +33,10 @@ services:
       - "--metrics-host=0.0.0.0"
       - "--max-fee-per-gas-gwei={{.Hyperdrive.AutoTxGasThresholdInt}}"
     networks:
-      - hyperdrive-network
+      - hyperdrive-net
     cap_drop:
       - all
     cap_add:
       - dac_override
     security_opt:
       - no-new-privileges
-networks:
-  hyperdrive-network:
-    name: {{.Hyperdrive.DockerNetwork}}
-    external: true

--- a/install/deploy/templates/modules/stakewise/sw_operator.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_operator.tmpl
@@ -33,10 +33,19 @@ services:
       - "--metrics-host=0.0.0.0"
       - "--max-fee-per-gas-gwei={{.Hyperdrive.AutoTxGasThresholdInt}}"
     networks:
-      - hyperdrive-net
+      - net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
     cap_drop:
       - all
     cap_add:
       - dac_override
     security_opt:
       - no-new-privileges
+networks:
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}

--- a/install/deploy/templates/modules/stakewise/sw_operator.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_operator.tmpl
@@ -33,7 +33,7 @@ services:
       - "--metrics-host=0.0.0.0"
       - "--max-fee-per-gas-gwei={{.Hyperdrive.AutoTxGasThresholdInt}}"
     networks:
-      - net
+      - hyperdrive-network
     cap_drop:
       - all
     cap_add:
@@ -41,4 +41,6 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  net:
+  hyperdrive-network:
+    name: {{.Hyperdrive.DockerNetwork}}
+    external: true

--- a/install/deploy/templates/modules/stakewise/sw_vc.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_vc.tmpl
@@ -17,7 +17,10 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - {{$module_dir}}/{{.ValidatorsDirectory}}:/{{.ValidatorsDirectory}}
     networks:
-      - hyperdrive-net
+      - net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.GetSelectedBeaconNode}}
@@ -43,3 +46,9 @@ services:
       - dac_override
     security_opt:
       - no-new-privileges
+networks:
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}

--- a/install/deploy/templates/modules/stakewise/sw_vc.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_vc.tmpl
@@ -17,7 +17,7 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - {{$module_dir}}/{{.ValidatorsDirectory}}:/{{.ValidatorsDirectory}}
     networks:
-      - net
+      - hyperdrive-network
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.GetSelectedBeaconNode}}
@@ -44,4 +44,6 @@ services:
     security_opt:
       - no-new-privileges
 networks:
-  net:
+  hyperdrive-network:
+    name: {{.Hyperdrive.DockerNetwork}}
+    external: true

--- a/install/deploy/templates/modules/stakewise/sw_vc.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_vc.tmpl
@@ -17,7 +17,7 @@ services:
       - /usr/share/hyperdrive/scripts:/usr/share/hyperdrive/scripts:ro
       - {{$module_dir}}/{{.ValidatorsDirectory}}:/{{.ValidatorsDirectory}}
     networks:
-      - hyperdrive-network
+      - hyperdrive-net
     environment:
       - NETWORK={{.Hyperdrive.Network}}
       - CLIENT={{.Hyperdrive.GetSelectedBeaconNode}}
@@ -43,7 +43,3 @@ services:
       - dac_override
     security_opt:
       - no-new-privileges
-networks:
-  hyperdrive-network:
-    name: {{.Hyperdrive.DockerNetwork}}
-    external: true

--- a/install/deploy/templates/prometheus.tmpl
+++ b/install/deploy/templates/prometheus.tmpl
@@ -22,7 +22,7 @@ services:
       - "{{.Hyperdrive.GetUserDirectory}}/extra-scrape-jobs:/extra-scrape-jobs"
       - "prometheus-data:/prometheus"
     networks:
-      - net
+      - hyperdrive-net
       - monitor-net
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -37,6 +37,5 @@ networks:
         - subnet: 172.23.0.0/16
           ip_range: 172.23.5.0/24
           gateway: 172.23.5.254
-  net:
 volumes:
   prometheus-data:

--- a/install/deploy/templates/prometheus.tmpl
+++ b/install/deploy/templates/prometheus.tmpl
@@ -22,8 +22,11 @@ services:
       - "{{.Hyperdrive.GetUserDirectory}}/extra-scrape-jobs:/extra-scrape-jobs"
       - "prometheus-data:/prometheus"
     networks:
-      - hyperdrive-net
+      - net
       - monitor-net
+      {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+      - {{$network}}
+      {{- end}}
     extra_hosts:
       - "host.docker.internal:host-gateway"
 networks:
@@ -37,5 +40,10 @@ networks:
         - subnet: 172.23.0.0/16
           ip_range: 172.23.5.0/24
           gateway: 172.23.5.254
+  net:
+  {{- range $network := .Hyperdrive.GetAdditionalDockerNetworks}}
+  {{$network}}:
+    external: true
+  {{- end}}
 volumes:
   prometheus-data:


### PR DESCRIPTION
This PR addresses the issue of running a hyperdrive client on the same machine as a rocketpool node and allows the containers to network through the `rocketpool_net` docker network

Adding the explicit network name `hyperdrive-net` and making the name and external fields configurable
```
networks:
  hyperdrive-net:
    name: {{.Hyperdrive.DockerNetwork}}
    external: {{.Hyperdrive.DockerNetworkIsExternal}}
```

With the the network set to `rocketpool_net` and `external=true`
<img width="454" alt="image" src="https://github.com/nodeset-org/hyperdrive/assets/6580386/92992355-ea9f-4cc5-bd2a-1065f593755e">

The clients can be connected to like so
<img width="377" alt="image" src="https://github.com/nodeset-org/hyperdrive/assets/6580386/fd83a0fc-33be-4fbe-84cd-d7f47c74f6f2">
<img width="325" alt="image" src="https://github.com/nodeset-org/hyperdrive/assets/6580386/a9b7fdef-a1cd-40dd-bd00-4e753b02addc">


<img width="1166" alt="image" src="https://github.com/nodeset-org/hyperdrive/assets/6580386/20531483-d3d5-4225-bcfb-0315f4265a73">

Testing
* Tested with rp rpc ports set to closed and to external hosts
* Tested with rp old cli and beta v2
* Tested with hyperdrive running full node to ensure it works as a standalone

The new docker compose looks like:
```
hyperdrive s compose

name: hyperdrive
services:
  daemon:
    cap_add:
      - dac_override
      - chown
    cap_drop:
      - all
    command:
      - --user-dir
      - /home/pi/.hyperdrive
      - -m
      - stakewise
    container_name: hyperdrive_daemon
    image: nodeset/hyperdrive:v0.4.2-b1
    networks:
      hyperdrive-net: null
    restart: unless-stopped
    security_opt:
      - no-new-privileges
    volumes:
      - type: bind
        source: /var/run/docker.sock
        target: /var/run/docker.sock
        bind:
          create_host_path: true
      - type: bind
        source: /home/pi/.hyperdrive
        target: /home/pi/.hyperdrive
        bind:
          create_host_path: true
      - type: bind
        source: /home/pi/.hyperdrive/data
        target: /home/pi/.hyperdrive/data
        bind:
          create_host_path: true
      - type: bind
        source: /usr/share/hyperdrive/scripts
        target: /usr/share/hyperdrive/scripts
        read_only: true
        bind:
          create_host_path: true
      - type: bind
        source: /var/lib/hyperdrive/global
        target: /var/lib/hyperdrive/global
        bind:
          create_host_path: true
      - type: bind
        source: /var/lib/hyperdrive/data/hyperdrive
        target: /var/lib/hyperdrive/data/hyperdrive
        bind:
          create_host_path: true
    x-rp-comment: Add your customizations below this line
  sw_daemon:
    cap_add:
      - dac_override
      - chown
    cap_drop:
      - all
    command:
      - --module-dir
      - /home/pi/.hyperdrive/data/modules/stakewise
    container_name: hyperdrive_sw_daemon
    image: nodeset/hyperdrive-stakewise:v0.1.1
    networks:
      hyperdrive-net: null
    restart: unless-stopped
    security_opt:
      - no-new-privileges
    user: root
    volumes:
      - type: bind
        source: /var/run/docker.sock
        target: /var/run/docker.sock
        bind:
          create_host_path: true
      - type: bind
        source: /home/pi/.hyperdrive
        target: /home/pi/.hyperdrive
        bind:
          create_host_path: true
      - type: bind
        source: /home/pi/.hyperdrive/data/modules/stakewise
        target: /home/pi/.hyperdrive/data/modules/stakewise
        bind:
          create_host_path: true
    x-rp-comment: Add your customizations below this line
  sw_operator:
    cap_add:
      - dac_override
    cap_drop:
      - all
    command:
      - src/main.py
      - start
      - --data-dir=/home/pi/.hyperdrive/data/modules/stakewise
      - --deposit-data-file=/home/pi/.hyperdrive/data/modules/stakewise/deposit-data.json
      - --network=holesky
      - --vault=0x646F5285D195e08E309cF9A5aDFDF68D6Fcc51C4
      - --execution-endpoints=http://rocketpool_eth1:8545
      - --consensus-endpoints=http://rocketpool_eth2:5052
      - --hot-wallet-file=/home/pi/.hyperdrive/data/modules/stakewise/wallet.json
      - --hot-wallet-password-file=/home/pi/.hyperdrive/data/modules/stakewise/password.txt
      - --keystores-dir=/home/pi/.hyperdrive/data/modules/stakewise/validators/stakewise
      - --keystores-password-file=/home/pi/.hyperdrive/data/modules/stakewise/validators/stakewise/secret.txt
      - --enable-metrics
      - --metrics-host=0.0.0.0
      - --max-fee-per-gas-gwei=100
    container_name: hyperdrive_sw_operator
    image: europe-west4-docker.pkg.dev/stakewiselabs/public/v3-operator:v1.2.2
    networks:
      hyperdrive-net: null
    restart: unless-stopped
    security_opt:
      - no-new-privileges
    user: root
    volumes:
      - type: bind
        source: /home/pi/.hyperdrive/data/modules/stakewise
        target: /home/pi/.hyperdrive/data/modules/stakewise
        bind:
          create_host_path: true
    x-rp-comment: Add your customizations below this line
  sw_vc:
    cap_add:
      - dac_override
    cap_drop:
      - all
    command:
      - /usr/share/hyperdrive/scripts/start-vc.sh
    container_name: hyperdrive_sw_vc
    entrypoint:
      - sh
    environment:
      BITFLY_NODE_METRICS_ENDPOINT: https://beaconcha.in/api/v1/client/metrics
      BITFLY_NODE_METRICS_MACHINE_NAME: Hyperdrive Node
      BITFLY_NODE_METRICS_SECRET: ""
      BN_API_ENDPOINT: http://rocketpool_eth2:5052
      BN_RPC_ENDPOINT: ""
      CLIENT: lighthouse
      DOPPELGANGER_DETECTION: "true"
      ENABLE_BITFLY_NODE_METRICS: "false"
      ENABLE_METRICS: "false"
      FALLBACK_BN_API_ENDPOINT: ""
      FALLBACK_BN_RPC_ENDPOINT: ""
      FEE_RECIPIENT: 0xc98F25BcAA6B812a07460f18da77AF8385be7b56
      GRAFFITI: HD v0.4.2-b1
      NETWORK: holesky
      VC_ADDITIONAL_FLAGS: ""
      VC_METRICS_PORT: "9101"
    image: sigp/lighthouse:v5.1.3-modern
    networks:
      hyperdrive-net: null
    restart: unless-stopped
    security_opt:
      - no-new-privileges
    stop_grace_period: 3m0s
    user: root
    volumes:
      - type: bind
        source: /usr/share/hyperdrive/scripts
        target: /usr/share/hyperdrive/scripts
        read_only: true
        bind:
          create_host_path: true
      - type: bind
        source: /home/pi/.hyperdrive/data/modules/stakewise/validators
        target: /validators
        bind:
          create_host_path: true
    x-rp-comment: Add your customizations below this line
networks:
  hyperdrive-net:
    name: rocketpool_net
    external: true
```
