### PR TITLE
Hyperdrive reth max peers fix

### DIFF
--- a/install/deploy/scripts/start-ec.sh
+++ b/install/deploy/scripts/start-ec.sh
@@ -325,6 +325,7 @@ if [ "$CLIENT" = "reth" ]; then
 
     if [ ! -z "$EC_MAX_PEERS" ]; then
         CMD="$CMD --max-outbound-peers $EC_MAX_PEERS --max-inbound-peers $EC_MAX_PEERS"
+    fi
 
     exec ${CMD}
 

--- a/install/deploy/scripts/start-ec.sh
+++ b/install/deploy/scripts/start-ec.sh
@@ -323,6 +323,9 @@ if [ "$CLIENT" = "reth" ]; then
         CMD="$CMD --port $EC_P2P_PORT"
     fi
 
+    if [ ! -z "$EC_MAX_PEERS" ]; then
+        CMD="$CMD --max-outbound-peers $EC_MAX_PEERS --max-inbound-peers $EC_MAX_PEERS"
+
     exec ${CMD}
 
 fi


### PR DESCRIPTION
Patches install/deploy/scripts/start-ec.sh to pass --max-inbound-peers and --max-outbound-peers to reth.

Notably, for a node with proper inbound connectivity, MAX_EC_PEERS as set from the TUI will not be enforced, as the node will have MAX_EC_PEERS * 2 (inbound + outbound), but I thought this was a decent compromise since not all nodes will be configured properly to allow inbound peer connections.

Longer term fix is to expose both max-inbound-peers and --max-outbound-peers in the TUI for the Reth EC.
