### PR TITLE
Add Warnings about Reth

### DIFF
--- a/hyperdrive-cli/commands/service/config/settings-execution.go
+++ b/hyperdrive-cli/commands/service/config/settings-execution.go
@@ -54,6 +54,14 @@ func (configPage *ExecutionConfigPage) createContent() {
 	configPage.layout.createForm(&configPage.masterConfig.Hyperdrive.Network, "Execution Client Settings")
 	configPage.layout.setupEscapeReturnHomeHandler(configPage.home.md, configPage.home.homePage)
 
+	// Update the Reth descriptions
+	for _, option := range configPage.masterConfig.Hyperdrive.LocalExecutionClient.ExecutionClient.Options {
+		option.Description = getAugmentedLocalEcDescription(option.Value, option.Description)
+	}
+	for _, option := range configPage.masterConfig.Hyperdrive.ExternalExecutionClient.ExecutionClient.Options {
+		option.Description = getAugmentedExternalEcDescription(option.Value, option.Description)
+	}
+
 	// Set up the form items
 	configPage.clientModeDropdown = createParameterizedDropDown(&configPage.masterConfig.Hyperdrive.ClientMode, configPage.layout.descriptionBox)
 	configPage.localEcDropdown = createParameterizedDropDown(&configPage.masterConfig.Hyperdrive.LocalExecutionClient.ExecutionClient, configPage.layout.descriptionBox)

--- a/hyperdrive-cli/commands/service/config/step-ec-warnings.go
+++ b/hyperdrive-cli/commands/service/config/step-ec-warnings.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rocket-pool/node-manager-core/config"
+)
+
+const (
+	localRethWarning    string = "[orange]WARNING: Reth is still in beta and has been shown to have some incompatibilities with the StakeWise Operator service, preventing you from submitting validator deposits properly. We strongly recommend you pick a different client instead until the incompatibility is fixed."
+	externalRethWarning string = "[orange]WARNING: Reth is still in beta and has been shown to have some incompatibilities with the StakeWise Operator service, preventing you from submitting validator deposits properly. We strongly recommend avoiding it as your external client until the incompatibility is fixed."
+)
+
+// Get a more verbose client description, including warnings
+func getAugmentedLocalEcDescription(client config.ExecutionClient, originalDescription string) string {
+	switch client {
+	case config.ExecutionClient_Reth:
+		if !strings.HasSuffix(originalDescription, localRethWarning) {
+			return fmt.Sprintf("%s\n\n%s", originalDescription, localRethWarning)
+		}
+	}
+
+	return originalDescription
+}
+
+// Get a more verbose client description, including warnings
+func getAugmentedExternalEcDescription(client config.ExecutionClient, originalDescription string) string {
+	switch client {
+	case config.ExecutionClient_Reth:
+		if !strings.HasSuffix(originalDescription, externalRethWarning) {
+			return fmt.Sprintf("%s\n\n%s", originalDescription, externalRethWarning)
+		}
+	}
+
+	return originalDescription
+}
+
+func createLocalRethWarningStep(wiz *wizard, currentStep int, totalSteps int) *choiceWizardStep {
+	helperText := localRethWarning
+
+	show := func(modal *choiceModalLayout) {
+		wiz.md.setPage(modal.page)
+		modal.focus(0)
+	}
+
+	done := func(buttonIndex int, buttonLabel string) {
+		if buttonIndex == 0 {
+			wiz.localEcModal.show()
+		} else {
+			wiz.localBnModal.show()
+		}
+	}
+
+	back := func() {
+		wiz.localEcModal.show()
+	}
+
+	return newChoiceStep(
+		wiz,
+		currentStep,
+		totalSteps,
+		helperText,
+		[]string{"Choose Again", "Keep Reth"},
+		[]string{},
+		76,
+		"Execution Client > Selection",
+		DirectionalModalHorizontal,
+		show,
+		done,
+		back,
+		"step-local-reth-warning",
+	)
+}
+
+func createExternalRethWarningStep(wiz *wizard, currentStep int, totalSteps int) *choiceWizardStep {
+	helperText := externalRethWarning
+
+	show := func(modal *choiceModalLayout) {
+		wiz.md.setPage(modal.page)
+		modal.focus(0)
+	}
+
+	done := func(buttonIndex int, buttonLabel string) {
+		wiz.externalEcSettingsModal.show()
+	}
+
+	back := func() {
+		wiz.externalEcSelectModal.show()
+	}
+
+	return newChoiceStep(
+		wiz,
+		currentStep,
+		totalSteps,
+		helperText,
+		[]string{"I Understand"},
+		[]string{},
+		76,
+		"Execution Client (External) > Selection",
+		DirectionalModalHorizontal,
+		show,
+		done,
+		back,
+		"step-external-reth-warning",
+	)
+}

--- a/hyperdrive-cli/commands/service/config/step-external-ec-select.go
+++ b/hyperdrive-cli/commands/service/config/step-external-ec-select.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/rocket-pool/node-manager-core/config"
+
 func createExternalEcSelectStep(wiz *wizard, currentStep int, totalSteps int) *choiceWizardStep {
 	// Create the button names and descriptions from the config
 	clients := wiz.md.Config.Hyperdrive.ExternalExecutionClient.ExecutionClient.Options
@@ -25,7 +27,13 @@ func createExternalEcSelectStep(wiz *wizard, currentStep int, totalSteps int) *c
 	done := func(buttonIndex int, buttonLabel string) {
 		selectedClient := clients[buttonIndex].Value
 		wiz.md.Config.Hyperdrive.ExternalExecutionClient.ExecutionClient.Value = selectedClient
-		wiz.externalEcSettingsModal.show()
+
+		if selectedClient == config.ExecutionClient_Reth {
+			// Show the Reth warning
+			wiz.externalRethWarning.show()
+		} else {
+			wiz.externalEcSettingsModal.show()
+		}
 	}
 
 	back := func() {

--- a/hyperdrive-cli/commands/service/config/step-local-ec.go
+++ b/hyperdrive-cli/commands/service/config/step-local-ec.go
@@ -14,7 +14,10 @@ func createLocalEcStep(wiz *wizard, currentStep int, totalSteps int) *choiceWiza
 	badClients := []*config.ParameterOption[config.ExecutionClient]{}
 	for _, client := range wiz.md.Config.Hyperdrive.LocalExecutionClient.ExecutionClient.Options {
 		if !strings.HasPrefix(client.Name, "*") {
-			goodClients = append(goodClients, client)
+			if client.Value != config.ExecutionClient_Reth {
+				// Remove Reth from the list of random options for now
+				goodClients = append(goodClients, client)
+			}
 		} else {
 			badClients = append(badClients, client)
 		}
@@ -38,7 +41,7 @@ func createLocalEcStep(wiz *wizard, currentStep int, totalSteps int) *choiceWiza
 	clientDescriptions := []string{randomDesc.String()}
 	for _, client := range clients {
 		clientNames = append(clientNames, client.Name)
-		clientDescriptions = append(clientDescriptions, client.Description)
+		clientDescriptions = append(clientDescriptions, getAugmentedLocalEcDescription(client.Value, client.Description))
 	}
 
 	helperText := "Please select the Execution Client you would like to use.\n\nHighlight each one to see a brief description of it, or go to https://clientdiversity.org/ to learn more about them."
@@ -81,8 +84,14 @@ func createLocalEcStep(wiz *wizard, currentStep int, totalSteps int) *choiceWiza
 			if selectedClient == config.ExecutionClient_Unknown {
 				panic(fmt.Sprintf("Local EC selection buttons didn't match any known clients, buttonLabel = %s\n", buttonLabel))
 			}
+
 			wiz.md.Config.Hyperdrive.LocalExecutionClient.ExecutionClient.Value = selectedClient
-			wiz.localBnModal.show()
+			if selectedClient == config.ExecutionClient_Reth {
+				// Show the Reth warning
+				wiz.localRethWarning.show()
+			} else {
+				wiz.localBnModal.show()
+			}
 		}
 	}
 

--- a/hyperdrive-cli/commands/service/config/wizard.go
+++ b/hyperdrive-cli/commands/service/config/wizard.go
@@ -16,7 +16,9 @@ type wizard struct {
 	// Step 4 - EC settings
 	localEcModal            *choiceWizardStep
 	localEcRandomModal      *choiceWizardStep
+	localRethWarning        *choiceWizardStep
 	externalEcSelectModal   *choiceWizardStep
+	externalRethWarning     *choiceWizardStep
 	externalEcSettingsModal *textBoxWizardStep
 
 	// Step 5 - BN settings
@@ -72,7 +74,9 @@ func newWizard(md *mainDisplay) *wizard {
 
 	// Step 4 - EC settings
 	wiz.localEcModal = createLocalEcStep(wiz, stepCount, totalSteps)
+	wiz.localRethWarning = createLocalRethWarningStep(wiz, stepCount, totalSteps)
 	wiz.externalEcSelectModal = createExternalEcSelectStep(wiz, stepCount, totalSteps)
+	wiz.externalRethWarning = createExternalRethWarningStep(wiz, stepCount, totalSteps)
 	wiz.externalEcSettingsModal = createExternalEcSettingsStep(wiz, stepCount, totalSteps)
 	stepCount++
 


### PR DESCRIPTION
Reth is currently incompatible with the StakeWise Operator for unknown reasons. This adds some warnings to the TUI when choosing it.