### PR TITLE
Fix `sw-operator`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1
 	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240925062001-b632dbb34408
-	github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1
+	github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240925070320-bce5c78f04f8
 	github.com/nodeset-org/osha v0.3.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/rivo/tview v0.0.0-20230208211350-7dfff1ce7854 // DO NOT UPGRADE

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mholt/archiver/v4 v4.0.0-alpha.8
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1
-	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1
+	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240925062001-b632dbb34408
 	github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1
 	github.com/nodeset-org/osha v0.3.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1 h1:vCfp3lmem13o/0v8MvIUhpN+dc9jeINflPWTAH68lXA=
 github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1/go.mod h1:QSgHk/fUfxGV0b9xP+9InyGhWQVvX1s0L8EA2PN7vfo=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1 h1:F9GU8p9u7qv98VVA93Bj4UunT5hO/c662mJe1ZRkgG8=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1/go.mod h1:jrX22jxBfFxbmFYm+4TknWPVrOG2RZL0zglG7+Mijf4=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240925062001-b632dbb34408 h1:OScvvo1bQlPLM8Kc0PaCc2qf4O7e4wvnIi/Yl2b6izA=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240925062001-b632dbb34408/go.mod h1:jrX22jxBfFxbmFYm+4TknWPVrOG2RZL0zglG7+Mijf4=
 github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1 h1:YOImrtms3AT0Uio0k01IVWsacG77YcijP4BKIPzecig=
 github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1/go.mod h1:U6fGpE2EgXxpDYQ+YGQqq8Wm3uVl3SW8jl8XJ0YV50I=
 github.com/nodeset-org/nodeset-client-go v1.0.0 h1:ZbYdP3nEFuZMT3Yt0nbBIYMdQZ4rAHMccvKjnUPZxhc=

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1 h1:vCfp3lmem13o/0v8MvI
 github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1/go.mod h1:QSgHk/fUfxGV0b9xP+9InyGhWQVvX1s0L8EA2PN7vfo=
 github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240925062001-b632dbb34408 h1:OScvvo1bQlPLM8Kc0PaCc2qf4O7e4wvnIi/Yl2b6izA=
 github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240925062001-b632dbb34408/go.mod h1:jrX22jxBfFxbmFYm+4TknWPVrOG2RZL0zglG7+Mijf4=
-github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1 h1:YOImrtms3AT0Uio0k01IVWsacG77YcijP4BKIPzecig=
-github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1/go.mod h1:U6fGpE2EgXxpDYQ+YGQqq8Wm3uVl3SW8jl8XJ0YV50I=
+github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240925070320-bce5c78f04f8 h1:IGCTYVbOYINLxNJ4pY9x9C4qNcjinWotATc+JY8vaJM=
+github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240925070320-bce5c78f04f8/go.mod h1:U6fGpE2EgXxpDYQ+YGQqq8Wm3uVl3SW8jl8XJ0YV50I=
 github.com/nodeset-org/nodeset-client-go v1.0.0 h1:ZbYdP3nEFuZMT3Yt0nbBIYMdQZ4rAHMccvKjnUPZxhc=
 github.com/nodeset-org/nodeset-client-go v1.0.0/go.mod h1:slpwejkJ/vYU9SKA3SYw4hIPJLzDUeQxcx+Cm04kkIA=
 github.com/nodeset-org/osha v0.3.0 h1:oX9ZrFLKXhhxCWbABY4VAvsqvGUH790XNeENl46a4EY=

--- a/install/deploy/templates/modules/stakewise/sw_operator.tmpl
+++ b/install/deploy/templates/modules/stakewise/sw_operator.tmpl
@@ -21,7 +21,7 @@ services:
       - "--data-dir={{$module_dir}}"
       - "--database-dir={{$module_dir}}/db/{{.StakeWiseResources.Vault}}"
       - "--deposit-data-file={{$module_dir}}/{{.StakeWise.DepositDataFile}}"
-      - "--network={{.Hyperdrive.GetEthNetworkName}}"
+      - "--network={{.HyperdriveResources.EthNetworkName}}"
       - "--vault={{.StakeWiseResources.Vault}}"
       - "--execution-endpoints={{.Hyperdrive.GetEcHttpEndpointsWithFallback}}"
       - "--consensus-endpoints={{.Hyperdrive.GetBnHttpEndpointsWithFallback}}"


### PR DESCRIPTION
This fixes #144. The template was pulling the ETH network name from an old config parameter that isn't used anymore. This changes it to use the on-disk resource definition instead. It also updates the StakeWise module, which bumps the v3 operator to v2.1.2. 