### PR TITLE
Add MEV-Boost warnings for hybrid mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1.0.20240927181424-49653a316a20
 	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240927170333-9fee16a048f0
-	github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240925070320-bce5c78f04f8
+	github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240930165456-a849d41acf24
 	github.com/nodeset-org/osha v0.3.1-0.20240927160812-d66358d4e091
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/rivo/tview v0.0.0-20230208211350-7dfff1ce7854 // DO NOT UPGRADE

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1.0.20240927181424-49653
 github.com/nodeset-org/hyperdrive-constellation v1.0.0-b1.0.20240927181424-49653a316a20/go.mod h1:8gvihGSvHp1gxmI6ky7GZjKMfM8qEBi/KWBBlDYHebg=
 github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240927170333-9fee16a048f0 h1:E0k1xWwUBGA00P5cA2dtt0TdrN+k33hBmsWbUZ1w49Y=
 github.com/nodeset-org/hyperdrive-daemon v1.1.0-b1.0.20240927170333-9fee16a048f0/go.mod h1:sT7SE+9qhmATtO1Rvyfo5D+752OfZa7UEVEYsMnmtEE=
-github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240925070320-bce5c78f04f8 h1:IGCTYVbOYINLxNJ4pY9x9C4qNcjinWotATc+JY8vaJM=
-github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240925070320-bce5c78f04f8/go.mod h1:U6fGpE2EgXxpDYQ+YGQqq8Wm3uVl3SW8jl8XJ0YV50I=
+github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240930165456-a849d41acf24 h1:nSF3UNWaf8Itfg1AarPxE7/lQyf3IOZFBRjrSkwcnGk=
+github.com/nodeset-org/hyperdrive-stakewise v1.1.0-b1.0.20240930165456-a849d41acf24/go.mod h1:dJzKkDmSzAFhilduv/zGzlABjmId+HTEXxmLM/tFmzs=
 github.com/nodeset-org/nodeset-client-go v1.0.1-0.20240927160821-e348e05e2363 h1:iivCknAFZlpxPwbIDjPc9E2bnj55c2STrXT9MvuMzQM=
 github.com/nodeset-org/nodeset-client-go v1.0.1-0.20240927160821-e348e05e2363/go.mod h1:slpwejkJ/vYU9SKA3SYw4hIPJLzDUeQxcx+Cm04kkIA=
 github.com/nodeset-org/osha v0.3.1-0.20240927160812-d66358d4e091 h1:oAs4/Yx4jnsNdWh3vTKum1sXC8VCvsY1H2VFSRRkgjc=

--- a/hyperdrive-cli/commands/service/config/step-mev-mode.go
+++ b/hyperdrive-cli/commands/service/config/step-mev-mode.go
@@ -52,19 +52,27 @@ func createMevModeStep(wiz *wizard, currentStep int, totalSteps int) *choiceWiza
 			wiz.md.Config.Hyperdrive.MevBoost.Enable.Value = true
 			wiz.md.Config.Hyperdrive.MevBoost.Mode.Value = config.ClientMode_Local
 			wiz.md.Config.Hyperdrive.MevBoost.SelectionMode.Value = hdconfig.MevSelectionMode_All
-			wiz.finishedModal.show()
+			if wiz.md.Config.Hyperdrive.ClientMode.Value == config.ClientMode_External {
+				wiz.mevWarningModal.show()
+			} else {
+				wiz.finishedModal.show()
+			}
 		case 1:
 			wiz.md.Config.Hyperdrive.MevBoost.Enable.Value = true
 			wiz.md.Config.Hyperdrive.MevBoost.Mode.Value = config.ClientMode_Local
 			wiz.md.Config.Hyperdrive.MevBoost.SelectionMode.Value = hdconfig.MevSelectionMode_Manual
-			wiz.localMevModal.show()
+			if wiz.md.Config.Hyperdrive.ClientMode.Value == config.ClientMode_External {
+				wiz.mevWarningModal.show()
+			} else {
+				wiz.localMevModal.show()
+			}
 		case 2:
 			wiz.md.Config.Hyperdrive.MevBoost.Enable.Value = true
 			wiz.md.Config.Hyperdrive.MevBoost.Mode.Value = config.ClientMode_External
-			if wiz.md.Config.Hyperdrive.ClientMode.Value == config.ClientMode_Local {
-				wiz.externalMevModal.show()
+			if wiz.md.Config.Hyperdrive.ClientMode.Value == config.ClientMode_External {
+				wiz.mevWarningModal.show()
 			} else {
-				wiz.finishedModal.show()
+				wiz.externalMevModal.show()
 			}
 		case 3:
 			wiz.md.Config.Hyperdrive.MevBoost.Enable.Value = false

--- a/hyperdrive-cli/commands/service/config/step-mev-warning.go
+++ b/hyperdrive-cli/commands/service/config/step-mev-warning.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	hdconfig "github.com/nodeset-org/hyperdrive-daemon/shared/config"
+	"github.com/rocket-pool/node-manager-core/config"
+)
+
+const mevWarningID string = "step-mev-warning"
+
+func createMevWarningStep(wiz *wizard, currentStep int, totalSteps int) *choiceWizardStep {
+	helperText := mevWarning
+
+	show := func(modal *choiceModalLayout) {
+		wiz.md.setPage(modal.page)
+		modal.focus(0)
+	}
+
+	done := func(buttonIndex int, buttonLabel string) {
+		if wiz.md.Config.Hyperdrive.MevBoost.Mode.Value == config.ClientMode_Local {
+			if wiz.md.Config.Hyperdrive.MevBoost.SelectionMode.Value == hdconfig.MevSelectionMode_All {
+				wiz.finishedModal.show()
+			} else {
+				wiz.localMevModal.show()
+			}
+		} else {
+			if wiz.md.Config.Hyperdrive.ClientMode.Value == config.ClientMode_Local {
+				wiz.externalMevModal.show()
+			} else {
+				wiz.finishedModal.show()
+			}
+		}
+	}
+
+	back := func() {
+		wiz.mevModeModal.show()
+	}
+
+	return newChoiceStep(
+		wiz,
+		currentStep,
+		totalSteps,
+		helperText,
+		[]string{"Continue"},
+		[]string{},
+		76,
+		"MEV-Boost Mode",
+		DirectionalModalHorizontal,
+		show,
+		done,
+		back,
+		mevWarningID,
+	)
+}

--- a/hyperdrive-cli/commands/service/config/wizard.go
+++ b/hyperdrive-cli/commands/service/config/wizard.go
@@ -46,6 +46,7 @@ type wizard struct {
 	mevModeModal     *choiceWizardStep
 	localMevModal    *checkBoxWizardStep
 	externalMevModal *textBoxWizardStep
+	mevWarningModal  *choiceWizardStep
 
 	// Done
 	finishedModal *choiceWizardStep
@@ -108,6 +109,7 @@ func newWizard(md *mainDisplay) *wizard {
 	wiz.mevModeModal = createMevModeStep(wiz, stepCount, totalSteps)
 	wiz.localMevModal = createLocalMevStep(wiz, stepCount, totalSteps)
 	wiz.externalMevModal = createExternalMevStep(wiz, stepCount, totalSteps)
+	wiz.mevWarningModal = createMevWarningStep(wiz, stepCount, totalSteps)
 	stepCount++
 
 	// Done


### PR DESCRIPTION
This adds a warning modal to the wizard and the review page when MEV-Boost is enabled in hybrid mode. It should help remind users to make sure they have MEV-Boost enabled on the external Beacon Node.

Closes #149.