### PR TITLE
Add misc UI fixes

### DIFF
--- a/hyperdrive-cli/client/global-config.go
+++ b/hyperdrive-cli/client/global-config.go
@@ -195,8 +195,8 @@ func (c *GlobalConfig) Validate() []string {
 		case config.ClientMode_Local:
 			// In local MEV-boost mode, the user has to have at least one relay
 			relays := c.Hyperdrive.MevBoost.GetEnabledMevRelays()
-			if len(relays) == 0 {
-				errors = append(errors, "You have MEV-boost enabled in local mode but don't have any profiles or relays enabled. Please select at least one profile or relay to use MEV-boost.")
+			if len(relays) == 0 && c.Hyperdrive.MevBoost.CustomRelays.Value == "" {
+				errors = append(errors, "You have MEV-boost enabled in local mode but don't have any profiles or relays enabled, and don't have any custom relays entered. Please select at least one profile or relay, or enter at least one custom relay, to use MEV-boost.")
 			}
 		case config.ClientMode_External:
 			// In external MEV-boost mode, the user has to have an external URL if they're running Docker mode
@@ -251,8 +251,12 @@ func (c *GlobalConfig) GetChanges(oldConfig *GlobalConfig) ([]*config.ChangedSec
 
 	// Process all configs for changes
 	sectionList = getChanges(oldConfig.Hyperdrive, c.Hyperdrive, sectionList, changedContainers)
-	sectionList = getChanges(oldConfig.StakeWise, c.StakeWise, sectionList, changedContainers)
-	sectionList = getChanges(oldConfig.Constellation, c.Constellation, sectionList, changedContainers)
+	if c.StakeWise.Enabled.Value {
+		sectionList = getChanges(oldConfig.StakeWise, c.StakeWise, sectionList, changedContainers)
+	}
+	if c.Constellation.Enabled.Value {
+		sectionList = getChanges(oldConfig.Constellation, c.Constellation, sectionList, changedContainers)
+	}
 
 	// Add all VCs to the list of changed containers if any change requires a VC change
 	if changedContainers[config.ContainerID_ValidatorClient] {

--- a/hyperdrive-cli/client/global-config.go
+++ b/hyperdrive-cli/client/global-config.go
@@ -258,6 +258,9 @@ func (c *GlobalConfig) GetChanges(oldConfig *GlobalConfig) ([]*config.ChangedSec
 	if changedContainers[config.ContainerID_ValidatorClient] {
 		delete(changedContainers, config.ContainerID_ValidatorClient)
 		for _, module := range c.GetAllModuleConfigs() {
+			if !module.IsEnabled() {
+				continue
+			}
 			vcInfo := module.GetValidatorContainerTagInfo()
 			for name := range vcInfo {
 				changedContainers[name] = true

--- a/hyperdrive-cli/commands/constellation/minipool/create.go
+++ b/hyperdrive-cli/commands/constellation/minipool/create.go
@@ -43,6 +43,14 @@ func createMinipool(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Get the minipool salt
 	var salt *big.Int

--- a/hyperdrive-cli/commands/constellation/minipool/exit.go
+++ b/hyperdrive-cli/commands/constellation/minipool/exit.go
@@ -57,6 +57,14 @@ func exitMinipools(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Get the local force flag
 	enableManualMode := c.Bool(exitManualModeFlag.Name)

--- a/hyperdrive-cli/commands/constellation/minipool/stake.go
+++ b/hyperdrive-cli/commands/constellation/minipool/stake.go
@@ -30,6 +30,14 @@ func stakeMinipools(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Build the TX
 	response, err := cs.Api.Minipool.Stake()

--- a/hyperdrive-cli/commands/constellation/minipool/status.go
+++ b/hyperdrive-cli/commands/constellation/minipool/status.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	csapi "github.com/nodeset-org/hyperdrive-constellation/shared/api"
 	"github.com/nodeset-org/hyperdrive/hyperdrive-cli/client"
-	"github.com/nodeset-org/hyperdrive/hyperdrive-cli/utils"
 	"github.com/nodeset-org/hyperdrive/hyperdrive-cli/utils/terminal"
 	"github.com/rocket-pool/node-manager-core/eth"
 	nmc_utils "github.com/rocket-pool/node-manager-core/utils"
@@ -33,6 +32,14 @@ func getMinipoolStatus(c *cli.Context) error {
 	cs, err := client.NewConstellationClientFromCtx(c, hd)
 	if err != nil {
 		return err
+	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
 	}
 
 	// Get minipool statuses
@@ -215,25 +222,6 @@ func printMinipoolDetails(minipool csapi.MinipoolDetails, latestDelegate common.
 		} else {
 			fmt.Printf("Validator seen:        no\n")
 		}
-	}
-
-	// Withdrawal details - withdrawable minipools
-	if minipool.Status.Status == types.MinipoolStatus_Withdrawable {
-		fmt.Printf("Withdrawal available:  yes\n")
-	}
-
-	// Delegate details
-	if minipool.UseLatestDelegate {
-		fmt.Printf("Use latest delegate:   yes\n")
-	} else {
-		fmt.Printf("Use latest delegate:   no\n")
-	}
-	fmt.Printf("Delegate address:      %s\n", utils.GetPrettyAddress(minipool.Delegate))
-	fmt.Printf("Rollback delegate:     %s\n", utils.GetPrettyAddress(minipool.PreviousDelegate))
-	fmt.Printf("Effective delegate:    %s\n", utils.GetPrettyAddress(minipool.EffectiveDelegate))
-
-	if minipool.EffectiveDelegate != latestDelegate {
-		fmt.Printf("%s*Minipool can be upgraded to delegate %s!%s\n", terminal.ColorYellow, latestDelegate.Hex(), terminal.ColorReset)
 	}
 
 	fmt.Println()

--- a/hyperdrive-cli/commands/constellation/minipool/upload-signed-exits.go
+++ b/hyperdrive-cli/commands/constellation/minipool/upload-signed-exits.go
@@ -32,6 +32,14 @@ func uploadSignedExits(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Get the details about each minipool
 	var selectedMinipools []*csapi.MinipoolExitDetails

--- a/hyperdrive-cli/commands/constellation/minipool/vanity.go
+++ b/hyperdrive-cli/commands/constellation/minipool/vanity.go
@@ -53,6 +53,14 @@ func findVanitySalt(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Get the target prefix
 	prefix := c.String(vanityPrefixFlag.Name)

--- a/hyperdrive-cli/commands/constellation/network/get-status.go
+++ b/hyperdrive-cli/commands/constellation/network/get-status.go
@@ -21,6 +21,14 @@ func getStats(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Get the network stats
 	response, err := cs.Api.Network.Stats()

--- a/hyperdrive-cli/commands/constellation/node/get-status.go
+++ b/hyperdrive-cli/commands/constellation/node/get-status.go
@@ -17,6 +17,14 @@ func getStatus(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Get the node status
 	response, err := cs.Api.Node.GetRegistrationStatus()

--- a/hyperdrive-cli/commands/constellation/node/register-node.go
+++ b/hyperdrive-cli/commands/constellation/node/register-node.go
@@ -28,6 +28,14 @@ func registerNode(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Check if the node's already registered
 	if !c.Bool(registerForceFlag.Name) {

--- a/hyperdrive-cli/commands/constellation/wallet/rebuild.go
+++ b/hyperdrive-cli/commands/constellation/wallet/rebuild.go
@@ -41,6 +41,14 @@ func rebuildValidatorKeys(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.Constellation.Enabled.Value {
+		fmt.Println("The Constellation module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Get the all flag
 	rebuildAll := c.Bool(rebuildAllFlag.Name)

--- a/hyperdrive-cli/commands/service/config/review-page.go
+++ b/hyperdrive-cli/commands/service/config/review-page.go
@@ -64,8 +64,12 @@ func NewReviewPage(md *mainDisplay, oldConfig *client.GlobalConfig, newConfig *c
 		// TEMP: Restart all of the module daemons if the HD daemon is being restarted
 		for container := range totalAffectedContainers {
 			if container == config.ContainerID_Daemon {
-				totalAffectedContainers[swconfig.ContainerID_StakewiseDaemon] = true
-				totalAffectedContainers[csconfig.ContainerID_ConstellationDaemon] = true
+				if newConfig.StakeWise.Enabled.Value {
+					totalAffectedContainers[swconfig.ContainerID_StakewiseDaemon] = true
+				}
+				if newConfig.Constellation.Enabled.Value {
+					totalAffectedContainers[csconfig.ContainerID_ConstellationDaemon] = true
+				}
 			}
 		}
 

--- a/hyperdrive-cli/commands/service/start.go
+++ b/hyperdrive-cli/commands/service/start.go
@@ -118,8 +118,9 @@ func startService(c *cli.Context, ignoreConfigSuggestion bool) error {
 
 	// Write a note on doppelganger protection
 	for _, module := range cfg.GetAllModuleConfigs() {
-		if module.IsDoppelgangerEnabled() {
+		if module.IsEnabled() && module.IsDoppelgangerEnabled() {
 			fmt.Printf("%sNOTE: You currently have Doppelganger Protection enabled on at least one module.\nYour Validator Client will miss up to 3 attestations when it starts.\nThis is *intentional* and does not indicate a problem with your node.%s\n\n", terminal.ColorBold, terminal.ColorReset)
+			break
 		}
 	}
 

--- a/hyperdrive-cli/commands/stakewise/nodeset/generate-deposit-data.go
+++ b/hyperdrive-cli/commands/stakewise/nodeset/generate-deposit-data.go
@@ -33,6 +33,14 @@ func generateDepositData(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.StakeWise.Enabled.Value {
+		fmt.Println("The StakeWise module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Parse the pubkeys
 	pubkeyStrings := c.StringSlice(generatePubkeyFlag.Name)

--- a/hyperdrive-cli/commands/stakewise/nodeset/upload-deposit-data.go
+++ b/hyperdrive-cli/commands/stakewise/nodeset/upload-deposit-data.go
@@ -1,6 +1,8 @@
 package nodeset
 
 import (
+	"fmt"
+
 	"github.com/nodeset-org/hyperdrive/hyperdrive-cli/client"
 	swcmdutils "github.com/nodeset-org/hyperdrive/hyperdrive-cli/commands/stakewise/utils"
 	"github.com/urfave/cli/v2"
@@ -15,6 +17,14 @@ func uploadDepositData(c *cli.Context) error {
 	sw, err := client.NewStakewiseClientFromCtx(c, hd)
 	if err != nil {
 		return err
+	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.StakeWise.Enabled.Value {
+		fmt.Println("The StakeWise module is not enabled in your Hyperdrive configuration.")
+		return nil
 	}
 
 	// Upload to the server

--- a/hyperdrive-cli/commands/stakewise/status/get-node-status.go
+++ b/hyperdrive-cli/commands/stakewise/status/get-node-status.go
@@ -20,6 +20,14 @@ func getNodeStatus(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.StakeWise.Enabled.Value {
+		fmt.Println("The StakeWise module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Check the registration status first
 	shouldContinue, err := nodeset.CheckRegistrationStatus(c, hd)

--- a/hyperdrive-cli/commands/stakewise/validator/exit.go
+++ b/hyperdrive-cli/commands/stakewise/validator/exit.go
@@ -40,6 +40,14 @@ func exit(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.StakeWise.Enabled.Value {
+		fmt.Println("The StakeWise module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Check wallet status
 	_, ready, err := utils.CheckIfWalletReady(hd)

--- a/hyperdrive-cli/commands/stakewise/wallet/claim-rewards.go
+++ b/hyperdrive-cli/commands/stakewise/wallet/claim-rewards.go
@@ -22,6 +22,14 @@ func claimRewards(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.StakeWise.Enabled.Value {
+		fmt.Println("The StakeWise module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Check if there's a node address ready
 	_, ready, err := utils.CheckIfAddressReady(hd)

--- a/hyperdrive-cli/commands/stakewise/wallet/generate-keys.go
+++ b/hyperdrive-cli/commands/stakewise/wallet/generate-keys.go
@@ -36,6 +36,14 @@ func generateKeys(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.StakeWise.Enabled.Value {
+		fmt.Println("The StakeWise module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 	noRestart := c.Bool(generateKeysNoRestartFlag.Name)
 
 	// Check wallet status

--- a/hyperdrive-cli/commands/stakewise/wallet/initialize.go
+++ b/hyperdrive-cli/commands/stakewise/wallet/initialize.go
@@ -19,6 +19,14 @@ func initialize(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cfg, _, err := hd.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading Hyperdrive config: %w", err)
+	}
+	if !cfg.StakeWise.Enabled.Value {
+		fmt.Println("The StakeWise module is not enabled in your Hyperdrive configuration.")
+		return nil
+	}
 
 	// Check wallet status
 	_, ready, err := utils.CheckIfWalletReady(hd)

--- a/install/packages/debian/debian/changelog
+++ b/install/packages/debian/debian/changelog
@@ -7,6 +7,7 @@ hyperdrive (1.1.1) UNRELEASED; urgency=medium
   * The max fee selection prompt now properly shows the low and high transaction cost range, instead of just showing the high cost twice.
   * Running Constellation or StakeWise commands without them enabled will now print a proper error message instead of a connection error.
   * Removed delegate info from `cs minipool status` since it is not relevant for Constellation node operators.
+  * The `service config` validation routine will now work properly if you don't have any of the default MEV-Boost relays enabled but do have your own custom relays.
 
  -- NodeSet Inc. <info@nodeset.io>  Sat, 26 Oct 2024 08:58:43 +0000
 

--- a/install/packages/debian/debian/changelog
+++ b/install/packages/debian/debian/changelog
@@ -5,6 +5,8 @@ hyperdrive (1.1.1) UNRELEASED; urgency=medium
   * New global flags: `--itsf` can be used to ignore TX simulation failues and sign / submit TXs anyway, even if they will revert. `--fgl` can force a specific gas limit on all transactions created by whatever command is being run. Do NOT use these unless you know what you're doing and have a good reason.
   * Added `--sbc` and `--slc` to `cs minipool create` which skip node balance and Constellation liquidity checks. Only use this if you intent to sign (but not submit) a TX for manual bundling or submission at a later date when the on-chain conditions become correct.
   * The max fee selection prompt now properly shows the low and high transaction cost range, instead of just showing the high cost twice.
+  * Running Constellation or StakeWise commands without them enabled will now print a proper error message instead of a connection error.
+  * Removed delegate info from `cs minipool status` since it is not relevant for Constellation node operators.
 
  -- NodeSet Inc. <info@nodeset.io>  Sat, 26 Oct 2024 08:58:43 +0000
 


### PR DESCRIPTION
This adds a few scattered UI fixes people have reported:
- Running `sw` or `cs` commands without the module(s) enabled will now print a message about them not being enabled, rather than report a nebulous error about not being able to connect to the daemons (since they don't exist).
- Removed the delegate info from `cs m s` since it's not relevant to Constellation users.
- The TUI's review screen now ignores containers from disabled modules in the list of containers that need to be restarted.
- The note about doppelganger detection in `service start` now only shows up once if you have multiple modules with VCs enabled.
- MEV-Boost's validation now works if you disable all of the built-in relays but have your own custom one(s).

Fixes #176.