### PR TITLE
Improve some fee settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/goccy/go-json v0.10.3
 	github.com/mholt/archiver/v4 v4.0.0-alpha.8
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nodeset-org/hyperdrive-constellation v1.0.1-0.20241026081320-11e85b6985dc
-	github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241026055334-466e711d8cf9
+	github.com/nodeset-org/hyperdrive-constellation v1.0.1-0.20241028174540-e6e5c956b603
+	github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241028171353-e4b6a5d23ef7
 	github.com/nodeset-org/hyperdrive-stakewise v1.1.0
 	github.com/nodeset-org/osha v0.3.1
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58

--- a/go.sum
+++ b/go.sum
@@ -448,10 +448,10 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/hyperdrive-constellation v1.0.1-0.20241026081320-11e85b6985dc h1:cV1Dr36lh5iZHDoeLL2Hf4xqsxXU705uRecP9LiMxWA=
-github.com/nodeset-org/hyperdrive-constellation v1.0.1-0.20241026081320-11e85b6985dc/go.mod h1:fUY7PuLA9x79FzGXxUQAHevvIIUM/jULbTWXkLSc8WY=
-github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241026055334-466e711d8cf9 h1:QaNrJ4KChRDQUAg+9OTxIe6p0pvjL+X5I65/pfNWo3A=
-github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241026055334-466e711d8cf9/go.mod h1:Sy7Kl0785VqraP+xwwFnYbSDhBlulJGWco1Kw75AXKQ=
+github.com/nodeset-org/hyperdrive-constellation v1.0.1-0.20241028174540-e6e5c956b603 h1:lTVqdKoMfl8uN/nMiaCyG/clmhMD4rFtQId/g8zD5yU=
+github.com/nodeset-org/hyperdrive-constellation v1.0.1-0.20241028174540-e6e5c956b603/go.mod h1:2eCK41hcfazkH42v+Xr6GBleJKrKOtAgzcso+1NMd3s=
+github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241028171353-e4b6a5d23ef7 h1:11jfimBTQWhIHAwce1PyOldq4yYxLR2fgDcmN7ztGRM=
+github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241028171353-e4b6a5d23ef7/go.mod h1:Sy7Kl0785VqraP+xwwFnYbSDhBlulJGWco1Kw75AXKQ=
 github.com/nodeset-org/hyperdrive-stakewise v1.1.0 h1:JiquGP1ewiAcqJmas8Vz6x298rAA8n/0qIiqb8RmcyM=
 github.com/nodeset-org/hyperdrive-stakewise v1.1.0/go.mod h1:SqPlbylTPdKKq9gdm3JWHis/DOkFD9DOubHDC/MfQ6o=
 github.com/nodeset-org/nodeset-client-go v1.2.1 h1:2Nybz1IONZBCD+j4+MgRBIvA3dNW4+ek1+kFtB/D6MY=

--- a/hyperdrive-cli/client/global-config.go
+++ b/hyperdrive-cli/client/global-config.go
@@ -189,6 +189,29 @@ func (c *GlobalConfig) Validate() []string {
 	}
 	*/
 
+	// Ensure the fee settings are ok
+	autoTxMaxFee := c.Hyperdrive.AutoTxMaxFee.Value
+	prioFee := c.Hyperdrive.MaxPriorityFee.Value
+	gasThreshold := c.Hyperdrive.AutoTxGasThreshold.Value
+	if autoTxMaxFee < 0 {
+		errors = append(errors, "Auto TX Max Fee cannot be negative.")
+	}
+	if prioFee <= 0 {
+		errors = append(errors, "Max Priority Fee must be greater than 0.")
+	}
+	if gasThreshold < 0 {
+		errors = append(errors, "Auto TX Gas Threshold cannot be negative.")
+	}
+	if autoTxMaxFee > 0 && prioFee > autoTxMaxFee {
+		errors = append(errors, "Max Priority Fee cannot be greater than Auto TX Max Fee.")
+	}
+	if gasThreshold > 0 && prioFee > gasThreshold {
+		errors = append(errors, "Max Priority Fee cannot be greater than Auto TX Gas Threshold.")
+	}
+	if autoTxMaxFee > 0 && gasThreshold > 0 && autoTxMaxFee >= gasThreshold {
+		errors = append(errors, "Auto TX Max Fee must be less than Auto TX Gas Threshold.")
+	}
+
 	// Ensure there's a MEV-boost URL
 	if c.Hyperdrive.MevBoost.Enable.Value {
 		switch c.Hyperdrive.MevBoost.Mode.Value {

--- a/install/packages/debian/debian/changelog
+++ b/install/packages/debian/debian/changelog
@@ -8,6 +8,10 @@ hyperdrive (1.1.1) UNRELEASED; urgency=medium
   * Running Constellation or StakeWise commands without them enabled will now print a proper error message instead of a connection error.
   * Removed delegate info from `cs minipool status` since it is not relevant for Constellation node operators.
   * The `service config` validation routine will now work properly if you don't have any of the default MEV-Boost relays enabled but do have your own custom relays.
+  * The default max fee has been reduced to 20, and the default max priority fee has been reduced to 0.1. Note this only affects new users that are configuring Hyperdrive for the first time.
+  * Automatic TXs will now ignore the gas threshold setting if a manual max fee is specified, as the threshold setting is only useful for dynamic network-based fees.
+  * Automatic TXs will now lower the max priority fee down to the max fee if the priority fee is greater than the max fee.
+  * Added additional validation to `service config` so the above conditions should not normally be possible anyway.
 
  -- NodeSet Inc. <info@nodeset.io>  Sat, 26 Oct 2024 08:58:43 +0000
 


### PR DESCRIPTION
This adds validation to prevent the user from misconfiguring fee settings (like making the priority fee higher than the max fee) and ignores the gas threshold when the max fee is explicitly set.

Also reduces the default max fee to 20, and the default max priority fee to 0.1. This will only apply to new installs so it's probably a good idea to PSA this for existing users.

Fixes #173.