### PR TITLE
Add auto-restart to `service install` and the .deb package

### DIFF
--- a/hyperdrive-cli/client/package.go
+++ b/hyperdrive-cli/client/package.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// Starts Hyperdrive as the provided user
+// Starts Hyperdrive as the provided user via `su`
 func StartServiceAsUser(uid uint32, hyperdriveBin string, configPath string) bool {
 	// Get the user from the uid
 	user, err := user.LookupId(fmt.Sprintf("%d", uid))
@@ -24,79 +24,19 @@ func StartServiceAsUser(uid uint32, hyperdriveBin string, configPath string) boo
 		hyperdriveCmd = append(hyperdriveCmd, "--allow-root")
 	}
 	hyperdriveCmd = append(hyperdriveCmd, "--config-path", configPath, "service", "start", "-y")
+	hyperdriveCmdStr := fmt.Sprintf("%s", strings.Join(hyperdriveCmd, " "))
 
-	// Check for sudo first
-	sudo := "sudo"
-	exists, _ := checkIfCommandExists(sudo)
-	if exists {
-		err := startServiceAsUserViaSudo(name, hyperdriveCmd)
-		if err == nil {
-			return true
-		}
-		fmt.Printf("WARN: Error starting Hyperdrive as user %d via sudo: %s\n", uid, err.Error())
+	// Run `su` to start Hyperdrive as the user
+	cmd := &command{
+		cmd: exec.Command("su", "-l", name, "-c", hyperdriveCmdStr),
+	}
+	err = runStartServiceCommand(cmd)
+	if err == nil {
+		return true
 	}
 
-	// Check for su next
-	su := "su"
-	exists, _ = checkIfCommandExists(su)
-	if exists {
-		err := startServiceAsUserViaSu(name, hyperdriveCmd)
-		if err == nil {
-			return true
-		}
-		fmt.Printf("WARN: Error starting Hyperdrive as user %d via su: %s\n", uid, err.Error())
-	}
-
-	/*
-		// Check for doas next
-		doas := "doas"
-		exists, _ = checkIfCommandExists(doas)
-		if exists {
-			err := startServiceAsUserViaDoas(name, hyperdriveCmd)
-			if err == nil {
-				return true
-			}
-			fmt.Printf("WARN: Error starting Hyperdrive as user %d via doas: %s\n", uid, err.Error())
-		}
-	*/
-
-	fmt.Printf("ERROR: All privilege escalation commands to start Hyperdrive as user %d failed or were not found.\n", uid)
+	fmt.Printf("WARN: Error starting Hyperdrive as user '%s' (%d): %s\n", name, uid, err.Error())
 	return false
-}
-
-// Starts Hyperdrive as the provided user via `sudo`
-func startServiceAsUserViaSudo(name string, hyperdriveCmd []string) error {
-	// Set up the args for sudo
-	args := []string{
-		"-i",
-		"-u",
-		name,
-	}
-	args = append(args, hyperdriveCmd...)
-
-	// Create the command and set the output to the terminal
-	cmd := &command{
-		cmd: exec.Command("sudo", args...),
-	}
-	return runStartServiceCommand(cmd)
-}
-
-// Starts Hyperdrive as the provided user via `su`
-func startServiceAsUserViaSu(name string, hyperdriveCmd []string) error {
-	// Set up the args for su
-	args := []string{
-		"-l",
-		name,
-		"-c",
-	}
-	hyperdriveCmdStr := fmt.Sprintf("'%s'", strings.Join(hyperdriveCmd, " "))
-	args = append(args, hyperdriveCmdStr)
-
-	// Create the command and set the output to the terminal
-	cmd := &command{
-		cmd: exec.Command("su", args...),
-	}
-	return runStartServiceCommand(cmd)
 }
 
 // Runs the given service start command

--- a/hyperdrive-cli/client/package.go
+++ b/hyperdrive-cli/client/package.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"strings"
+)
+
+// Starts Hyperdrive as the provided user
+func StartServiceAsUser(uid uint32, hyperdriveBin string, configPath string) bool {
+	// Get the user from the uid
+	user, err := user.LookupId(fmt.Sprintf("%d", uid))
+	if err != nil {
+		fmt.Printf("ERROR: Could not find user with ID %d: %s\n", uid, err.Error())
+		return false
+	}
+	name := user.Username
+
+	// Prep the hyperdrive command
+	hyperdriveCmd := []string{hyperdriveBin}
+	if uid == 0 {
+		hyperdriveCmd = append(hyperdriveCmd, "--allow-root")
+	}
+	hyperdriveCmd = append(hyperdriveCmd, "--config-path", configPath, "service", "start", "-y")
+
+	// Check for sudo first
+	sudo := "sudo"
+	exists, _ := checkIfCommandExists(sudo)
+	if exists {
+		err := startServiceAsUserViaSudo(name, hyperdriveCmd)
+		if err == nil {
+			return true
+		}
+		fmt.Printf("WARN: Error starting Hyperdrive as user %d via sudo: %s\n", uid, err.Error())
+	}
+
+	// Check for su next
+	su := "su"
+	exists, _ = checkIfCommandExists(su)
+	if exists {
+		err := startServiceAsUserViaSu(name, hyperdriveCmd)
+		if err == nil {
+			return true
+		}
+		fmt.Printf("WARN: Error starting Hyperdrive as user %d via su: %s\n", uid, err.Error())
+	}
+
+	/*
+		// Check for doas next
+		doas := "doas"
+		exists, _ = checkIfCommandExists(doas)
+		if exists {
+			err := startServiceAsUserViaDoas(name, hyperdriveCmd)
+			if err == nil {
+				return true
+			}
+			fmt.Printf("WARN: Error starting Hyperdrive as user %d via doas: %s\n", uid, err.Error())
+		}
+	*/
+
+	fmt.Printf("ERROR: All privilege escalation commands to start Hyperdrive as user %d failed or were not found.\n", uid)
+	return false
+}
+
+// Starts Hyperdrive as the provided user via `sudo`
+func startServiceAsUserViaSudo(name string, hyperdriveCmd []string) error {
+	// Set up the args for sudo
+	args := []string{
+		"-i",
+		"-u",
+		name,
+	}
+	args = append(args, hyperdriveCmd...)
+
+	// Create the command and set the output to the terminal
+	cmd := &command{
+		cmd: exec.Command("sudo", args...),
+	}
+	return runStartServiceCommand(cmd)
+}
+
+// Starts Hyperdrive as the provided user via `su`
+func startServiceAsUserViaSu(name string, hyperdriveCmd []string) error {
+	// Set up the args for su
+	args := []string{
+		"-l",
+		name,
+		"-c",
+	}
+	hyperdriveCmdStr := fmt.Sprintf("'%s'", strings.Join(hyperdriveCmd, " "))
+	args = append(args, hyperdriveCmdStr)
+
+	// Create the command and set the output to the terminal
+	cmd := &command{
+		cmd: exec.Command("su", args...),
+	}
+	return runStartServiceCommand(cmd)
+}
+
+// Runs the given service start command
+func runStartServiceCommand(cmd *command) error {
+	cmd.SetStdin(os.Stdin)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
+
+	// Run the command
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+	return cmd.Wait()
+}

--- a/hyperdrive-cli/client/package.go
+++ b/hyperdrive-cli/client/package.go
@@ -24,7 +24,7 @@ func StartServiceAsUser(uid uint32, hyperdriveBin string, configPath string) boo
 		hyperdriveCmd = append(hyperdriveCmd, "--allow-root")
 	}
 	hyperdriveCmd = append(hyperdriveCmd, "--config-path", configPath, "service", "start", "-y")
-	hyperdriveCmdStr := fmt.Sprintf("%s", strings.Join(hyperdriveCmd, " "))
+	hyperdriveCmdStr := strings.Join(hyperdriveCmd, " ")
 
 	// Run `su` to start Hyperdrive as the user
 	cmd := &command{

--- a/hyperdrive-cli/commands/nodeset/utils.go
+++ b/hyperdrive-cli/commands/nodeset/utils.go
@@ -23,7 +23,10 @@ func CheckRegistrationStatus(c *cli.Context, hd *client.HyperdriveClient) (bool,
 	}
 
 	// Prompt for registration
-	if !(c.Bool(utils.YesFlag.Name) || utils.Confirm("Would you like to register your node now?")) {
+	if c.Bool(utils.YesFlag.Name) {
+		return false, nil
+	}
+	if !utils.Confirm("Would you like to register your node now?") {
 		fmt.Println("Cancelled.")
 		return false, nil
 	}

--- a/hyperdrive-cli/commands/service/commands.go
+++ b/hyperdrive-cli/commands/service/commands.go
@@ -97,6 +97,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 					installVersionFlag,
 					installLocalScriptFlag,
 					installLocalPackageFlag,
+					installNoRestartFlag,
 				},
 				Action: func(c *cli.Context) error {
 					// Validate args
@@ -382,6 +383,24 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 
 					// Run command
 					return terminateService(c)
+				},
+			},
+
+			// Used by the package installers only
+			{
+				Name:    "safe-start-after-install",
+				Aliases: []string{"ssaf"},
+				Usage:   "Install the Hyperdrive service",
+				Hidden:  true,
+				Flags:   []cli.Flag{},
+				Action: func(c *cli.Context) error {
+					// Validate args
+					utils.ValidateArgCount(c, 1)
+					systemDir := c.Args().Get(0)
+
+					// Run command
+					safeStartAfterInstall(systemDir)
+					return nil
 				},
 			},
 		},

--- a/hyperdrive-cli/commands/service/install.go
+++ b/hyperdrive-cli/commands/service/install.go
@@ -46,15 +46,16 @@ var (
 
 // Install the Hyperdrive service
 func installService(c *cli.Context) error {
-	// Prompt for confirmation
-	fmt.Printf("Hyperdrive will be installed --Version: %s\n\n%sIf you're upgrading, your existing configuration will be backed up and preserved.\nAll of your previous settings will be migrated automatically.%s\n", c.String(installVersionFlag.Name), terminal.ColorGreen, terminal.ColorReset)
+	fmt.Printf("Hyperdrive will be installed --Version: %s\n\n%sIf you're upgrading, your existing configuration will be backed up and preserved.\nAll of your previous settings will be migrated automatically.", c.String(installVersionFlag.Name), terminal.ColorGreen)
 	fmt.Println()
 
 	if !c.Bool(installNoRestartFlag.Name) {
-		fmt.Printf("%sNOTE: after installing, all Hyperdrive-managed services (including your clients) will be restarted. If you have doppelganger detection enabled, any active validators will miss the next few attestations while it runs.%s\n", terminal.ColorYellow, terminal.ColorReset)
-		fmt.Println()
+		fmt.Print("The service will restart to apply the update (including restarting your clients). If you have doppelganger detection enabled, any active validators will miss the next few attestations while it runs.")
 	}
+	fmt.Printf("%s\n", terminal.ColorReset)
+	fmt.Println()
 
+	// Prompt for confirmation
 	if !(c.Bool(utils.YesFlag.Name) || utils.Confirm("Are you ready to continue?")) {
 		fmt.Println("Cancelled.")
 		return nil
@@ -113,7 +114,6 @@ func installService(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("error restarting services: %w", err)
 		}
-		fmt.Println("Services restarted successfully.")
 	} else {
 		fmt.Println("Remember to run `hyperdrive service start` to update to the new services!")
 	}

--- a/hyperdrive-cli/commands/service/safe-start-after-install.go
+++ b/hyperdrive-cli/commands/service/safe-start-after-install.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"syscall"
+
+	dtc "github.com/docker/docker/api/types/container"
+	dmount "github.com/docker/docker/api/types/mount"
+	docker "github.com/docker/docker/client"
+	"github.com/nodeset-org/hyperdrive/hyperdrive-cli/client"
+)
+
+const (
+	daemonBinLocation   string = "/usr/bin/hyperdrive-daemon"
+	daemonImageRegexStr string = "nodeset/hyperdrive:v.*"
+	daemonUserDirFlag   string = "--user-dir"
+)
+
+var (
+	daemonImageRegex *regexp.Regexp = regexp.MustCompile(daemonImageRegexStr)
+)
+
+// Called by package managers to restart the service after installation if it was already running
+// Note this is going to run as a superuser, not necessarily the user running Hyperdrive, so we can't rely on the default context flags
+func safeStartAfterInstall(systemDir string) {
+	hyperdriveBinPath := os.Args[0]
+
+	// Get a Docker client
+	d, err := docker.NewClientWithOpts(docker.WithAPIVersionNegotiation())
+	if err != nil {
+		fmt.Printf("Error creating Docker client: %s\n", err.Error())
+		return
+	}
+
+	// Get a list of all running images
+	cl, err := d.ContainerList(context.Background(), dtc.ListOptions{All: false})
+	if err != nil {
+		fmt.Printf("Error getting running Docker container list: %s\n", err.Error())
+		return
+	}
+
+	// Find the daemon containers
+	daemonIds := []string{}
+	for _, container := range cl {
+		isDaemon := daemonImageRegex.MatchString(container.Image)
+		if !isDaemon {
+			continue
+		}
+		name := strings.TrimPrefix(container.Names[0], "/")
+		fmt.Printf("Found running daemon container [%s] with image [%s]\n", name, container.Image)
+		daemonIds = append(daemonIds, container.ID)
+	}
+
+	// Run a service start for each daemon container
+	for _, id := range daemonIds {
+		containerInfo, err := d.ContainerInspect(context.Background(), id)
+		if err != nil {
+			fmt.Printf("Error inspecting container %s: %s\n", id, err.Error())
+			continue
+		}
+		containerName := strings.TrimPrefix(containerInfo.Name, "/")
+
+		// Make sure it has the system dir mounted
+		usesSystemDir := false
+		for _, mount := range containerInfo.Mounts {
+			if mount.Type != dmount.TypeBind {
+				continue
+			}
+			if !strings.HasPrefix(mount.Source, systemDir) {
+				continue
+			}
+			usesSystemDir = true
+			break
+		}
+		if !usesSystemDir {
+			fmt.Printf("Daemon container [%s] does not have the system dir mounted, skipping...\n", containerName)
+			continue
+		}
+
+		// Get the user dir from the args
+		userDir := ""
+		for i := 0; i < len(containerInfo.Args); i++ {
+			arg := containerInfo.Args[i]
+			if arg != daemonUserDirFlag {
+				continue
+			}
+			if i+1 >= len(containerInfo.Args) {
+				break
+			}
+			userDir = containerInfo.Args[i+1]
+			break
+		}
+		if userDir == "" {
+			// Couldn't get the user dir from the args, so skip this container
+			fmt.Printf("Daemon container [%s] does not have a user dir arg, skipping...\n", containerName)
+			continue
+		}
+
+		// Get the owner of the user dir
+		userDirStat := syscall.Stat_t{}
+		err = syscall.Stat(userDir, &userDirStat)
+		if err != nil {
+			fmt.Printf("Error getting user dir [%s] stat for [%s]: %s\n", userDir, containerName, err.Error())
+			continue
+		}
+		owner := userDirStat.Uid
+
+		// Start the service
+		success := client.StartServiceAsUser(owner, hyperdriveBinPath, userDir)
+		if !success {
+			fmt.Printf("WARN: starting service for container [%s] failed.\n", containerName)
+			fmt.Println("Please restart the service manually with `hyperdrive service start` to update the daemon services.")
+			continue
+		}
+	}
+}

--- a/hyperdrive-cli/utils/context/install_info.go
+++ b/hyperdrive-cli/utils/context/install_info.go
@@ -11,13 +11,13 @@ const (
 	TestSystemDirEnvVar string = "HYPERDRIVE_TEST_SYSTEM_DIR"
 
 	// System dir path for Linux
-	linuxSystemDir string = "/usr/share/hyperdrive"
+	LinuxSystemDir string = "/usr/share/hyperdrive"
 
 	// Subfolders under the system dir
-	scriptsDir        string = "scripts"
-	templatesDir      string = "templates"
-	overrideSourceDir string = "override"
-	networksDir       string = "networks"
+	ScriptsDir        string = "scripts"
+	TemplatesDir      string = "templates"
+	OverrideSourceDir string = "override"
+	NetworksDir       string = "networks"
 )
 
 // Holds information about Hyperdrive's installation on the system
@@ -43,14 +43,19 @@ func NewInstallationInfo() *InstallationInfo {
 		// This is where to add different paths for different OS's like macOS
 		default:
 			// By default just use the Linux path
-			systemDir = linuxSystemDir
+			systemDir = LinuxSystemDir
 		}
 	}
 
+	return NewInstallationInfoForSystemDir(systemDir)
+}
+
+// Creates a new installation info instance with the given system directory
+func NewInstallationInfoForSystemDir(systemDir string) *InstallationInfo {
 	return &InstallationInfo{
-		ScriptsDir:        filepath.Join(systemDir, scriptsDir),
-		TemplatesDir:      filepath.Join(systemDir, templatesDir),
-		OverrideSourceDir: filepath.Join(systemDir, overrideSourceDir),
-		NetworksDir:       filepath.Join(systemDir, networksDir),
+		ScriptsDir:        filepath.Join(systemDir, ScriptsDir),
+		TemplatesDir:      filepath.Join(systemDir, TemplatesDir),
+		OverrideSourceDir: filepath.Join(systemDir, OverrideSourceDir),
+		NetworksDir:       filepath.Join(systemDir, NetworksDir),
 	}
 }

--- a/install/packages/debian/debian/changelog
+++ b/install/packages/debian/debian/changelog
@@ -1,6 +1,8 @@
 hyperdrive (1.1.1) UNRELEASED; urgency=medium
 
   * Updated Besu, Nethermind, Reth, Prysm, Teku, and Prometheus.
+  * Installing Hyperdrive updates via `apt update` now prompts you to automatically restart the service so the daemons will be up to date.
+  * Installing manually via `hyperdrive service install` will now automatically restart the service unless the `--no-restart` flag is provided.
   * Fixed a bug that caused Rocket Pool contract queries to hang on single-CPU systems.
   * New global flags: `--itsf` can be used to ignore TX simulation failues and sign / submit TXs anyway, even if they will revert. `--fgl` can force a specific gas limit on all transactions created by whatever command is being run. Do NOT use these unless you know what you're doing and have a good reason.
   * Added `--sbc` and `--slc` to `cs minipool create` which skip node balance and Constellation liquidity checks. Only use this if you intent to sign (but not submit) a TX for manual bundling or submission at a later date when the on-chain conditions become correct.

--- a/install/packages/debian/debian/config
+++ b/install/packages/debian/debian/config
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+# Source debconf
+. /usr/share/debconf/confmodule
+
+# Check if this is a new install or an upgrade
+if [ ! -z "$2" ]; then
+    # Ask about restarting
+    db_input critical hyperdrive/restart || true
+    db_go
+else
+    db_set hyperdrive/restart false
+fi

--- a/install/packages/debian/debian/control
+++ b/install/packages/debian/debian/control
@@ -20,5 +20,7 @@ Depends:  chrony (>= 4.0),
           docker-ce-cli,
           docker-compose-plugin (>= 2.24.1),
           containerd.io (>= 1.6.4),
+          util-linux,
+          debconf,
           ${misc:Depends}, ${shlibs:Depends}
 Description: Hyperdrive is an all-in-one node management system for NodeSet node operators.

--- a/install/packages/debian/debian/postinst
+++ b/install/packages/debian/debian/postinst
@@ -1,3 +1,14 @@
 #!/bin/sh
 
-/usr/bin/hyperdrive --allow-root service safe-start-after-install /usr/share/hyperdrive
+# Source debconf
+. /usr/share/debconf/confmodule
+
+# Restart the service if requested
+db_get hyperdrive/restart
+if [ "$RET" = "true" ]; then
+    /usr/bin/hyperdrive --allow-root service safe-start-after-install /usr/share/hyperdrive || true
+fi
+
+# Reset the debconf "seen" flag for the next install 
+db_fset hyperdrive/restart seen false
+db_go

--- a/install/packages/debian/debian/postinst
+++ b/install/packages/debian/debian/postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/hyperdrive --allow-root service safe-start-after-install /usr/share/hyperdrive

--- a/install/packages/debian/debian/postrm
+++ b/install/packages/debian/debian/postrm
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Remove debconf DB changes when uninstalling
+if [ "$1" = "purge" -a -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/install/packages/debian/debian/templates
+++ b/install/packages/debian/debian/templates
@@ -2,7 +2,7 @@ Template: hyperdrive/restart
 Type: boolean
 Default: true
 Description: Do you want to restart Hyperdrive to apply the update?
-  Hyperdrive needs to be restarted in order to apply this update.
+  Any running Hyperdrive services need to be restarted in order to apply this update.
   NOTE: this may restart your Validator Clients if a new client version has been released.
   If you have Doppelganger detection enabled, it will trigger and you will miss a few attestations.
   This is normal.

--- a/install/packages/debian/debian/templates
+++ b/install/packages/debian/debian/templates
@@ -1,0 +1,8 @@
+Template: hyperdrive/restart
+Type: boolean
+Default: true
+Description: Do you want to restart Hyperdrive to apply the update?
+  Hyperdrive needs to be restarted in order to apply this update.
+  NOTE: this may restart your Validator Clients if a new client version has been released.
+  If you have Doppelganger detection enabled, it will trigger and you will miss a few attestations.
+  This is normal.


### PR DESCRIPTION
This enforces `service start` to manual installation via `service install` so the daemons will be up to date after installing a new version. Also adds auto-restarting and an interactive prompt to the .deb package, which shows up during updates (but not new installations or purges).

Closes #171 and #172.