### PR TITLE
Fix #175

### DIFF
--- a/hyperdrive-cli/commands/service/config.go
+++ b/hyperdrive-cli/commands/service/config.go
@@ -103,7 +103,7 @@ func configureService(c *cli.Context) error {
 				return nil
 			}
 
-			err = changeNetworks(c, hd)
+			err = changeNetworks(c)
 			if err != nil {
 				fmt.Printf("%s%s%s\nHyperdrive could not automatically change networks for you, so you will have to remove your old data folder manually.\n", terminal.ColorRed, err.Error(), terminal.ColorReset)
 			}

--- a/hyperdrive-cli/commands/service/utils.go
+++ b/hyperdrive-cli/commands/service/utils.go
@@ -23,12 +23,17 @@ func getComposeFiles(c *cli.Context) []string {
 }
 
 // Handle a network change by terminating the service, deleting everything, and starting over
-func changeNetworks(c *cli.Context, hd *client.HyperdriveClient) error {
+func changeNetworks(c *cli.Context) error {
+	// Create a new Hyperdrive client - important to ensure the config is loaded from disk and isn't the stale old one
+	hd, err := client.NewHyperdriveClientFromCtx(c)
+	if err != nil {
+		return err
+	}
 	composeFiles := getComposeFiles(c)
 
 	// Purge the data folder
 	fmt.Print("Purging data folder... ")
-	err := hd.PurgeData(composeFiles, false)
+	err = hd.PurgeData(composeFiles, false)
 	if err != nil {
 		return fmt.Errorf("error purging data folder: %w", err)
 	}


### PR DESCRIPTION
This fixes #175. Previously `changeNetworks()` was using the existing HD client binding, which had the old configuration loaded. The fix is to make it reload the configuration from disk after the updated one has been saved, so it grabs the correct new network resource values.