### PR TITLE
Added a last-minute Teku update

### DIFF
--- a/install/deploy/networks/holesky.yml
+++ b/install/deploy/networks/holesky.yml
@@ -14,6 +14,9 @@ networkResources:
   capellaForkVersion: 0x04017000
   capellaForkEpoch: 256
 defaultConfigSettings:
+  localBeacon:
+    teku:
+      containerTag: "consensys/teku:25.4.1"
 hyperdriveResources:
   nodeSetApiUrl: https://nodeset.io/api
   encryptionPubkey: age1hs87f8pl369tel4xpprtmaxwhg2e3gynvz8q45h48hed4m4h4d0s6t8caa

--- a/install/deploy/networks/hoodi.yml
+++ b/install/deploy/networks/hoodi.yml
@@ -14,6 +14,9 @@ networkResources:
   capellaForkVersion: 0x40000910
   capellaForkEpoch: 0
 defaultConfigSettings:
+  localBeacon:
+    teku:
+      containerTag: "consensys/teku:25.4.1"
 hyperdriveResources:
   nodeSetApiUrl: https://nodeset.io/api
   encryptionPubkey: age1hs87f8pl369tel4xpprtmaxwhg2e3gynvz8q45h48hed4m4h4d0s6t8caa

--- a/install/deploy/networks/mainnet.yml
+++ b/install/deploy/networks/mainnet.yml
@@ -14,6 +14,9 @@ networkResources:
   capellaForkVersion: 0x03000000
   capellaForkEpoch: 194048
 defaultConfigSettings:
+  localBeacon:
+    teku:
+      containerTag: "consensys/teku:25.4.1"
 hyperdriveResources:
   nodeSetApiUrl: https://nodeset.io/api
   encryptionPubkey: age1hs87f8pl369tel4xpprtmaxwhg2e3gynvz8q45h48hed4m4h4d0s6t8caa

--- a/install/deploy/networks/modules/constellation/holesky.yml
+++ b/install/deploy/networks/modules/constellation/holesky.yml
@@ -1,5 +1,7 @@
 key: holesky
 defaultConfigSettings:
+  teku:
+    containerTag: "consensys/teku:25.4.1"
 constellationResources:
   deploymentName: holesky
   directory: 0x925D0700407fB0C855Ae9903B3a2727F1e88576c

--- a/install/deploy/networks/modules/constellation/hoodi.yml
+++ b/install/deploy/networks/modules/constellation/hoodi.yml
@@ -1,5 +1,7 @@
 key: hoodi
 defaultConfigSettings:
+  teku:
+    containerTag: "consensys/teku:25.4.1"
 constellationResources:
   deploymentName: hoodi
   directory: 0x925D0700407fB0C855Ae9903B3a2727F1e88576c

--- a/install/deploy/networks/modules/constellation/mainnet.yml
+++ b/install/deploy/networks/modules/constellation/mainnet.yml
@@ -1,5 +1,7 @@
 key: mainnet
 defaultConfigSettings:
+  teku:
+    containerTag: "consensys/teku:25.4.1"
 constellationResources:
   deploymentName: mainnet
   directory: 0x4343743dBc46F67D3340b45286D8cdC13c8575DE

--- a/install/deploy/networks/modules/stakewise/holesky.yml
+++ b/install/deploy/networks/modules/stakewise/holesky.yml
@@ -1,5 +1,7 @@
 key: holesky
 defaultConfigSettings:
+  teku:
+    containerTag: "consensys/teku:25.4.1"
 stakeWiseResources:
   deploymentName: holesky
   vault: 0x646F5285D195e08E309cF9A5aDFDF68D6Fcc51C4

--- a/install/deploy/networks/modules/stakewise/hoodi.yml
+++ b/install/deploy/networks/modules/stakewise/hoodi.yml
@@ -1,5 +1,7 @@
 key: hoodi
 defaultConfigSettings:
+  teku:
+    containerTag: "consensys/teku:25.4.1"
 stakeWiseResources:
   deploymentName: hoodi
   vault: 0x2b3eb77e5cbde5deb70c928e1e2814f8a6f143e0

--- a/install/deploy/networks/modules/stakewise/mainnet.yml
+++ b/install/deploy/networks/modules/stakewise/mainnet.yml
@@ -1,5 +1,7 @@
 key: mainnet
 defaultConfigSettings:
+  teku:
+    containerTag: "consensys/teku:25.4.1"
 stakeWiseResources:
   deploymentName: mainnet
   vault: 0xE2AEECC76839692AEa35a8D119181b14ebf411c9

--- a/install/packages/debian/debian/changelog
+++ b/install/packages/debian/debian/changelog
@@ -1,9 +1,14 @@
-hyperdrive (1.2.0~b1) UNRELEASED; urgency=medium
+hyperdrive (1.2.0~b1) unstable; urgency=medium
 
-  * Introduced support for StakeWise v3 vaults
+  * Updated Geth, Besu, Reth, and the Node Exporter.
+  * Added `--full` to Reth so it retains deposit event logs, which is required for StakeWise.
+  * Updated Lighthouse for test networks only.
+  * Redesigned the StakeWise module to support StakeWise v3 vaults. It will no longer function with legacy StakeWise v1 vaults, but those have been deprecated from nodeset.io anyway.
+  * Disabled the StakeWise module on Mainnet, and enabled it on Hoodi.
+  * Added validator key recovery to the StakeWise commands.
 
- -- NodeSet Inc. <info@nodeset.io>  Fri, 21 Mar 2025 16:04:11 +0000
- 
+ -- NodeSet Inc. <info@nodeset.io>  Thu, 17 Apr 2025 19:35:09 +0000
+
 hyperdrive (1.1.4) stable; urgency=medium
 
   * Updated Geth, Besu, Nethermind, Reth, Lodestar, Nimbus, Prysm, Teku, and the Node Exporter.


### PR DESCRIPTION
Teku pushed a high-priority update in the middle of our release process, so this updates the default container tag to use it.