### PR TITLE
Make Prysm work in a pure POSIX environment

### DIFF
--- a/install/deploy/scripts/start-bn.sh
+++ b/install/deploy/scripts/start-bn.sh
@@ -175,18 +175,6 @@ fi
 # Prysm startup
 if [ "$CLIENT" = "prysm" ]; then
 
-    # Grab the Hoodi genesis state if needed
-    if [ "$ETH_NETWORK" = "hoodi" ]; then
-        echo "Prysm is configured to use Hoodi, genesis state required."
-        if [ ! -f "/ethclient/hoodi-genesis.ssz" ]; then
-            echo "Downloading from Github..."
-            wget -q https://github.com/eth-clients/hoodi/raw/refs/heads/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
-            echo "Download complete."
-        else
-            echo "Genesis state already downloaded, continuing."
-        fi
-    fi
-
     CMD="$PERF_PREFIX /app/cmd/beacon-chain/beacon-chain \
         --accept-terms-of-use \
         --$ETH_NETWORK \
@@ -218,12 +206,12 @@ if [ "$CLIENT" = "prysm" ]; then
         CMD="$CMD --disable-monitoring"
     fi
 
-    if [ "$ETH_NETWORK" = "hoodi" ]; then
-        CMD="$CMD --genesis-state /ethclient/hoodi-genesis.ssz"
-    fi
-
     if [ ! -z "$CHECKPOINT_SYNC_URL" ]; then
         CMD="$CMD --checkpoint-sync-url=$CHECKPOINT_SYNC_URL --genesis-beacon-api-url=$CHECKPOINT_SYNC_URL"
+    elif [ "$ETH_NETWORK" = "hoodi" ]; then
+        # Prysm can't retrieve the genesis state for Hoodi automatically,
+        # so we use the Checkpointz provider they recommend in the official docs.
+        CMD="$CMD --genesis-beacon-api-url=https://hoodi.beaconstate.info"
     fi
 
     exec ${CMD}

--- a/install/deploy/scripts/start-vc.sh
+++ b/install/deploy/scripts/start-vc.sh
@@ -126,9 +126,9 @@ if [ "$CLIENT" = "prysm" ]; then
     mkdir -p /validators/prysm-non-hd/
 
     # Get rid of the protocol prefix
-    BN_RPC_ENDPOINT=$(echo $BN_RPC_ENDPOINT | sed -E 's/.*\:\/\/(.*)/\1/')
+    BN_RPC_ENDPOINT="${BN_RPC_ENDPOINT#*://}"
     if [ ! -z "$FALLBACK_BN_RPC_ENDPOINT" ]; then
-        FALLBACK_BN_RPC_ENDPOINT=$(echo $FALLBACK_BN_RPC_ENDPOINT | sed -E 's/.*\:\/\/(.*)/\1/')
+        FALLBACK_BN_RPC_ENDPOINT="${FALLBACK_BN_RPC_ENDPOINT#*://}"
     fi
 
     # Set up the CC + fallback string


### PR DESCRIPTION
This follows on after https://github.com/OffchainLabs/prysm/pull/15294, which adds `/bin/sh` to the official Prysm images. Since they don't come with other typical binaries like `sed`, we can't use them in the scripts anymore. This changes the scripts to remove dependencies from external tools (except `echo` which is provided). The genesis state download just uses `https://hoodi.beaconstate.info` which is what the official docs suggest. The prefix removal for the RPC URLs just uses some POSIX magic instead of needing to use `sed`.