### PR TITLE
Ensure SW Operator restarts when gas threshold changes

### DIFF
--- a/hyperdrive-cli/commands/service/config/review-page.go
+++ b/hyperdrive-cli/commands/service/config/review-page.go
@@ -73,6 +73,13 @@ func NewReviewPage(md *mainDisplay, oldConfig *client.GlobalConfig, newConfig *c
 			}
 		}
 
+		// TEMP: If the gas threshold is changed, make sure the SW operator is restarted
+		if newConfig.StakeWise.Enabled.Value {
+			if oldConfig.Hyperdrive.AutoTxGasThreshold.Value != newConfig.Hyperdrive.AutoTxGasThreshold.Value {
+				totalAffectedContainers[swconfig.ContainerID_StakewiseOperator] = true
+			}
+		}
+
 		// Print the list of containers to restart
 		if builder.String() == "" {
 			builder.WriteString("<No changes>")


### PR DESCRIPTION
Since the SW Operator submits its own transactions and uses the Auto TX Gas Threshold setting, it needs to be restarted with the daemons whenever that setting changes. This is a short-term fix that explicitly forces it to update when the settings changes.