### PR TITLE
Feat: pull images before restart

### DIFF
--- a/hyperdrive-cli/client/service.go
+++ b/hyperdrive-cli/client/service.go
@@ -192,6 +192,15 @@ func (c *HyperdriveClient) StopService(composeFiles []string) error {
 	return printOutput(cmd)
 }
 
+// Pull new container images
+func (c *HyperdriveClient) PullImages(composeFiles []string) error {
+	cmd, err := c.compose(composeFiles, "pull -q")
+	if err != nil {
+		return err
+	}
+	return printOutput(cmd)
+}
+
 // Stop the Hyperdrive service, shutting it down and removing the Docker artifacts
 func (c *HyperdriveClient) DownService(composeFiles []string, includeVolumes bool) error {
 	args := "down"

--- a/hyperdrive-cli/commands/service/config.go
+++ b/hyperdrive-cli/commands/service/config.go
@@ -135,6 +135,14 @@ func configureService(c *cli.Context) error {
 				fmt.Fprintf(os.Stderr, "Warning: couldn't check running containers: %s\n", err.Error())
 				runningContainers = map[string]bool{}
 			}
+
+			// Let's reduce potential downtime by pulling the new containers before restarting
+			fmt.Println("Pulling potential new container images...")
+			err = hd.PullImages(getComposeFiles(c))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: couldn't pul new images for updated containers: %s\n", err.Error())
+			}
+
 			for _, container := range md.ContainersToRestart {
 				fullName := fmt.Sprintf("%s_%s", prefix, container)
 				if !runningContainers[fullName] {


### PR DESCRIPTION
### Description
This PR is a small optimization that will pull the new docker container images before stopping the currently running ones, resulting in less downtime than before.

### Motivation

I've been bitten by having to wait for several containers to be pulled before, which are not only causing unnecessary downtime, but can be especially painful if one gets rate-limited by dockerhub, or when there are other failure modes in the image pull scenario. (e.g. docker disk full - which is not necessarily the same as where the data volumes live)

With this change the containers won't be stopped until the new images are available, potentially preventing these issues and improving uptime.

### Changes

Old situation:
 * User updates/manually updates container image to different version
 * hyperdrive asks user to restart
 * user confirms, hyperdrive stops to be restarted containers
 * hyperdrive runs compose up, causing it to start pulling containers
 * containers start

New situation:
 * User updates/manually updates container image to different version
 * hyperdrive asks user to restart
 * user confirms, **_hyperdrive runs compose pull, causing it to pull new required container images_**
 * hyperdrive stops to be restarted containers
 * hyperdrive runs compose up
 * containers start
 Or in a screenshot:
<img width="610" height="251" alt="image" src="https://github.com/user-attachments/assets/2614c160-8b22-4a29-93b7-a93aea14e175" />
